### PR TITLE
Strash index was always calculated at 0, leading to 100% collisions

### DIFF
--- a/logic/c.go
+++ b/logic/c.go
@@ -266,7 +266,7 @@ func (p *C) And(a, b z.Lit) z.Lit {
 		return b
 	}
 	c := strashCode(a, b)
-	l := uint32(cap(p.nodes))
+	l := uint32(cap(p.nodes) - 1)
 	i := c % l
 	si := p.strash[i]
 	for {
@@ -282,7 +282,7 @@ func (p *C) And(a, b z.Lit) z.Lit {
 	m, j := p.newNode()
 	m.a = a
 	m.b = b
-	k := c % uint32(cap(p.nodes))
+	k := c % uint32(cap(p.nodes) - 1)
 	m.n = p.strash[k]
 	p.strash[k] = j
 	return z.Var(j).Pos()
@@ -367,7 +367,7 @@ func (p *C) grow() {
 			continue
 		}
 		c := strashCode(n.a, n.b)
-		j := c % ucap
+		j := c % (ucap - 1)
 		n.n = strash[j]
 		strash[j] = uint32(i)
 	}

--- a/sudoku_test.go
+++ b/sudoku_test.go
@@ -2,10 +2,17 @@ package gini_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/go-air/gini"
 	"github.com/go-air/gini/z"
 )
+
+func BenchmarkSudoku(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Example_sudoku()
+	}
+}
 
 func Example_sudoku() {
 	g := gini.New()


### PR DESCRIPTION
This is how the structural hash in gini is computed:
https://github.com/go-air/gini/blob/a1a5030366dd8610b5c38f4e7f26cf688dfd1f5a/logic/c.go#L379

But when it’s used, it’s used “mod capacity” of the nodes - which are always multiples of 2. The index into the strash array is always `a*2^13*b % 2^n` which is 0 for n<13:

https://github.com/go-air/gini/blob/a1a5030366dd8610b5c38f4e7f26cf688dfd1f5a/logic/c.go#L268-L271
https://github.com/go-air/gini/blob/a1a5030366dd8610b5c38f4e7f26cf688dfd1f5a/logic/c.go#L285-L287

and leads to 100% collisions on the table - it will always try to store in index 0 and have to walk back through the node links.

To fix this, I changed the index calculation to `strash % (cap - 1)`

I added a small benchmark that uses the existing sudoku example as a sanity check:

```
// before
BenchmarkSudoku-12    	     894	   1752632 ns/op
// after
BenchmarkSudoku-12    	     741	   1467374 ns/op
```
which is a ~15% speedup.

(I'm sure there are much better ways to check this; it seems like the `bench` command would work)

It's also entirely possible I'm not understanding what is supposed to be happening, please enlighten me if that's the case!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-air/gini/17)
<!-- Reviewable:end -->
